### PR TITLE
 Fetch more actors from TMDB when creating plex_movie records

### DIFF
--- a/packages/django-app/app/core/management/commands/backfill_actors.py
+++ b/packages/django-app/app/core/management/commands/backfill_actors.py
@@ -1,0 +1,20 @@
+import logging
+
+from django.core.management import BaseCommand
+
+from plex.commands import BackfillActorsCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command to backfill TMDB actors for existing PlexMovie records.
+    Usage: python manage.py backfill_actors
+    """
+    help = 'Backfill TMDB actors for all existing PlexMovie records'
+
+    def handle(self, *args, **options):
+        self.stdout.write('Starting actor backfill from TMDB...')
+        BackfillActorsCommand().execute()
+        self.stdout.write(self.style.SUCCESS('Actor backfill complete!'))

--- a/packages/django-app/app/plex/commands.py
+++ b/packages/django-app/app/plex/commands.py
@@ -6,6 +6,7 @@ from plexapi.myplex import MyPlexAccount
 
 from common.commands.abstract_base_command import AbstractBaseCommand
 from plex.repositories import PlexMovieRepository
+from services.tmdb import TMDB
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +41,19 @@ class SyncWithPlexCommand(AbstractBaseCommand):
                 return
 
             try:
+                # Get actors from Plex
+                plex_actors = [t.tag for t in movie.actors]
+
+                # Augment with TMDB actors
+                actors = self._get_augmented_actors(
+                    movie.title, movie.year, plex_actors)
+
                 movie_details = {
                     'plex_guid': movie.guid,
                     'title': movie.title,
                     'year': movie.year,
                     'duration': movie.duration,
-                    'actors': [t.tag for t in movie.actors],
+                    'actors': actors,
                     'genres': [t.tag for t in movie.genres],
                     'directors': [t.tag for t in movie.directors],
                     'producers': [t.tag for t in movie.producers],
@@ -59,3 +67,82 @@ class SyncWithPlexCommand(AbstractBaseCommand):
             except Exception as e:
                 logger.exception(f"Failed to create PlexMovie: {movie}")
                 logger.exception(e)
+
+    def _get_augmented_actors(self, title: str, year: int,
+                               plex_actors: list) -> list:
+        """
+        Fetch actors from TMDB and merge with Plex actors.
+        Returns a deduplicated list preserving order.
+        """
+        try:
+            tmdb_movie = TMDB.search_by_title_and_year(title, year)
+            if tmdb_movie:
+                tmdb_id = tmdb_movie['id']
+                tmdb_actors = TMDB.get_movie_credits(tmdb_id, cast_limit=20)
+
+                # Merge: TMDB actors first (more complete), then Plex actors
+                seen = set()
+                merged = []
+                for actor in tmdb_actors + plex_actors:
+                    actor_lower = actor.lower()
+                    if actor_lower not in seen:
+                        seen.add(actor_lower)
+                        merged.append(actor)
+                return merged
+        except Exception as e:
+            logger.warning(f"Failed to fetch TMDB actors for {title}: {e}")
+
+        return plex_actors
+
+
+class BackfillActorsCommand(AbstractBaseCommand):
+    """
+    Backfill TMDB actors for existing PlexMovie records.
+    Fetches top 20 actors from TMDB and merges with existing actors.
+    """
+
+    def execute(self) -> None:
+        super().execute()
+
+        movies = PlexMovieRepository.model.objects.all()
+        total = movies.count()
+        updated = 0
+        failed = 0
+
+        for i, movie in enumerate(movies, 1):
+            try:
+                tmdb_movie = TMDB.search_by_title_and_year(movie.title,
+                                                           movie.year)
+                if tmdb_movie:
+                    tmdb_id = tmdb_movie['id']
+                    tmdb_actors = TMDB.get_movie_credits(tmdb_id, cast_limit=20)
+
+                    # Merge actors (TMDB first, then existing)
+                    existing_actors = movie.actors or []
+                    seen = set()
+                    merged = []
+                    for actor in tmdb_actors + existing_actors:
+                        actor_lower = actor.lower()
+                        if actor_lower not in seen:
+                            seen.add(actor_lower)
+                            merged.append(actor)
+
+                    if len(merged) > len(existing_actors):
+                        movie.actors = merged
+                        movie.save()
+                        updated += 1
+                        print(f'[{i}/{total}] Updated: {movie.title} '
+                              f'({len(existing_actors)} -> {len(merged)} actors)')
+                    else:
+                        print(f'[{i}/{total}] Skipped: {movie.title} '
+                              f'(no new actors)')
+                else:
+                    print(f'[{i}/{total}] Not found on TMDB: {movie.title}')
+                    failed += 1
+
+            except Exception as e:
+                logger.exception(f"Failed to backfill actors for: {movie}")
+                failed += 1
+
+        print(f'\nBackfill complete: {updated} updated, {failed} failed, '
+              f'{total - updated - failed} unchanged')

--- a/packages/django-app/app/services/tmdb.py
+++ b/packages/django-app/app/services/tmdb.py
@@ -23,5 +23,27 @@ class TMDB:
         return response
 
     @classmethod
+    def search_by_title_and_year(cls, title: str, year: int):
+        """Search for a movie by title and year, returning the best match."""
+        search = tmdb.Search()
+        response = search.movie(query=title, year=year)
+        results = response.get('results', [])
+        if results:
+            return results[0]
+        return None
+
+    @classmethod
+    def get_movie_credits(cls, tmdb_id: int, cast_limit: int = 20):
+        """
+        Fetch movie credits (cast) from TMDB.
+        Returns a list of actor names, limited to cast_limit.
+        """
+        movie = tmdb.Movies(tmdb_id)
+        credits = movie.credits()
+        cast = credits.get('cast', [])
+        actor_names = [actor['name'] for actor in cast[:cast_limit]]
+        return actor_names
+
+    @classmethod
     def get_poster_full_path(cls, poster_path) -> str:
         return f'{cls.poster_base_url}{poster_path}'


### PR DESCRIPTION
## Summary

  - Enhance actor data by fetching up to 20 actors from TMDB credits API
  - Add backfill command to update existing movies with expanded actor lists
  - Improves /bacon command accuracy by providing more actor connections

  ---
 ## Changes

  services/tmdb.py

  - Added search_by_title_and_year() - finds TMDB movie by title + year
  - Added get_movie_credits() - fetches top N actors from TMDB credits endpoint

  plex/commands.py

  - Modified SyncWithPlexCommand to augment Plex actors with TMDB data
  - Added _get_augmented_actors() helper for merging and deduplicating actors
  - Added BackfillActorsCommand to update existing PlexMovie records

  core/management/commands/backfill_actors.py

  - Django management command wrapper for BackfillActorsCommand

  Usage

  ## Backfill existing movies (one-time)
  python manage.py backfill_actors

  ## New movies are automatically enriched during sync
  python manage.py sync_with_plex


#11 