### PR TITLE
Remove copy-paste cruft from service files

### DIFF
--- a/packages/django-app/app/services/ombi.py
+++ b/packages/django-app/app/services/ombi.py
@@ -2,14 +2,10 @@ import json
 import logging
 
 import requests
-import tmdbsimple as tmdb
 from django.conf import settings
 from requests.auth import HTTPBasicAuth
 
 logger = logging.getLogger(__name__)
-
-tmdb.API_KEY = settings.TMDB_TOKEN_V3
-tmdb.REQUESTS_SESSION = requests.Session()
 
 
 class Ombi:

--- a/packages/django-app/app/services/radarr.py
+++ b/packages/django-app/app/services/radarr.py
@@ -2,14 +2,10 @@ import json
 import logging
 
 import requests
-import tmdbsimple as tmdb
 from django.conf import settings
 from requests.auth import HTTPBasicAuth
 
 logger = logging.getLogger(__name__)
-
-tmdb.API_KEY = settings.TMDB_TOKEN_V3
-tmdb.REQUESTS_SESSION = requests.Session()
 
 
 class Radarr:


### PR DESCRIPTION
Removed unnecessary tmdbsimple import and configuration from ombi.py and radarr.py. These were copy/paste remnants from the TMDB service class template. Neither Ombi nor Radarr services use the tmdbsimple library - they only use the requests library directly to interact with their respective APIs.

Fixes #16