### PR TITLE
Fix Discord button creation with long movie titles

### DIFF
--- a/packages/django-app/app/discordbot/request_movie.py
+++ b/packages/django-app/app/discordbot/request_movie.py
@@ -86,8 +86,16 @@ def create_buttons(data) -> List[discord.ui.Button]:
     for item in data['results'][:3]:
         tmdb_id = item.get('id', None)
         if tmdb_id:
+            title = item['title']
+            # Discord button labels must be 80 characters or fewer
+            # "Request " is 8 characters, leaving 72 for the title
+            # If truncated, add "..." (leaving 69 chars for title + 3 for ellipsis)
+            max_title_length = 72
+            if len(title) > max_title_length:
+                title = title[:69] + "..."
+
             button = discord.ui.Button(
-                label=f"Request {item['title']}",
+                label=f"Request {title}",
                 style=discord.ButtonStyle.primary,
                 custom_id=f"tmdb_{tmdb_id}")
             buttons.append(button)


### PR DESCRIPTION
Truncate long movie titles in Discord button labels to comply with Discord's 80-character limit. Titles longer than 72 characters (80 minus "Request " prefix) are now truncated to 69 characters with "..." appended.

Fixes #3