### PR TITLE
Configure TCP connector with force_close for Discord bot

### DIFF
--- a/packages/django-app/app/core/management/commands/start_discord_bot.py
+++ b/packages/django-app/app/core/management/commands/start_discord_bot.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import aiohttp
 from aiohttp import ClientSession
 from discord.ext import commands
 from discordbot.bot import OscarrBot
@@ -8,7 +9,8 @@ from django.core.management import BaseCommand
 
 
 async def run():
-    async with ClientSession() as web_client:
+    connector = aiohttp.TCPConnector(force_close=True)
+    async with ClientSession(connector=connector) as web_client:
         async with OscarrBot(
             commands.when_mentioned,
             web_client=web_client,


### PR DESCRIPTION
## Summary
Updated the Discord bot's HTTP client initialization to explicitly configure the TCP connector with `force_close=True` to ensure proper connection handling.

## Key Changes
- Added explicit `aiohttp.TCPConnector` configuration when creating the `ClientSession`
- Set `force_close=True` on the connector to force closure of connections after each request
- This ensures more predictable connection lifecycle management and prevents potential connection pooling issues

## Implementation Details
The `ClientSession` is now initialized with a configured connector that forces TCP connections to close after use, rather than relying on the default connection pooling behavior. This can help prevent connection leaks and improve resource cleanup in long-running bot processes.

https://claude.ai/code/session_01SYC6X4KRLv3r3RpwvRSLQu