### PR TITLE
Refactor Discord bot to use dedicated service with profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint and Test
 
 on:
   push:
@@ -6,64 +6,90 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  quality-checks:
+  ci:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:16
-        env:
-          POSTGRES_USER: test_user
-          POSTGRES_PASSWORD: test_password
-          POSTGRES_DB: test_db
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    defaults:
-      run:
-        working-directory: packages/django-app
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # --- Fast fail-first: lint + format + types (native, no Docker) ---
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: packages/django-app/uv.lock
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version-file: packages/django-app/pyproject.toml
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
+      - name: Install Python dependencies
+        working-directory: ./packages/django-app
+        run: uv sync --frozen
 
-      - name: Install dependencies
-        run: uv sync --no-install-project
-
-      - name: Check formatting with ruff
+      - name: Check Python formatting (Ruff)
+        working-directory: ./packages/django-app
         run: uv run ruff format --check app
 
-      - name: Lint with ruff
+      - name: Lint Python code (Ruff)
+        working-directory: ./packages/django-app
         run: uv run ruff check app
 
-      - name: Type check with pyright
+      - name: Type check (Pyright)
+        working-directory: ./packages/django-app
         run: uv run pyright app
 
+      # --- Docker-based: build + migrate + django check + tests ---
+
+      - name: Install Just
+        uses: extractions/setup-just@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare .env for CI
+        working-directory: ./packages/django-app
+        run: |
+          just copy-env
+          SECRET_KEY=$(python3 -c 'import secrets, string; chars = string.ascii_letters + string.digits + "!@#$%^&*(-_=+)"; print("".join(secrets.choice(chars) for _ in range(50)))')
+          sed -i "s|SECRET_KEY_GOES_HERE|${SECRET_KEY}|" .env
+          sed -i "s|^DISCORD_TOKEN=.*|DISCORD_TOKEN=ci-test-token|" .env
+          sed -i "s|^PGCRYPTO_KEY=.*|PGCRYPTO_KEY=ci-test-pgcrypto-key-32chars|" .env
+
+      - name: Build web image (with GHA layer cache)
+        uses: docker/bake-action@v5
+        with:
+          workdir: ./packages/django-app
+          files: docker-compose.yml
+          targets: web
+          load: true
+          set: |
+            web.tags=oscarr-web:latest
+            web.cache-from=type=gha
+            web.cache-to=type=gha,mode=max
+
+      - name: Create volumes and bring up db
+        working-directory: ./packages/django-app
+        run: |
+          docker volume create --name=oscarr_postgres
+          docker compose up -d db
+          ./bin/wait-for-it.sh localhost:5432 -- echo "db is up"
+
+      - name: Run migrations
+        working-directory: ./packages/django-app
+        run: just dcp-migrate
+
+      - name: Run Django system checks
+        working-directory: ./packages/django-app
+        run: ./bin/dcp-django-admin.sh check --deploy
+
       - name: Run tests
-        run: uv run pytest app -m "not integration" --cov=app --verbose --cov-report=term
-        env:
-          DJANGO_SECRET_KEY: "test-secret-key-for-ci-only-not-production"
-          DEBUG: "False"
-          POSTGRES_DB: "test_db"
-          POSTGRES_USER: "test_user"
-          POSTGRES_PASSWORD: "test_password"
-          POSTGRES_HOST: "localhost"
-          POSTGRES_PORT: "5432"
-          DISCORD_TOKEN: "test-discord-token"
-          PGCRYPTO_KEY: "test-pgcrypto-key-32-characters"
+        working-directory: ./packages/django-app
+        run: just dcp-run-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Prepare .env for CI
+      - name: Copy environment file
+        working-directory: ./packages/django-app
+        run: just copy-env
+
+      - name: Generate secret key
         working-directory: ./packages/django-app
         run: |
-          just copy-env
           SECRET_KEY=$(python3 -c 'import secrets, string; chars = string.ascii_letters + string.digits + "!@#$%^&*(-_=+)"; print("".join(secrets.choice(chars) for _ in range(50)))')
           sed -i "s|SECRET_KEY_GOES_HERE|${SECRET_KEY}|" .env
           sed -i "s|^DISCORD_TOKEN=.*|DISCORD_TOKEN=ci-test-token|" .env
@@ -75,10 +78,13 @@ jobs:
             web.cache-from=type=gha
             web.cache-to=type=gha,mode=max
 
-      - name: Create volumes and bring up db
+      - name: Create volumes
+        working-directory: ./packages/django-app
+        run: docker volume create --name=oscarr_postgres
+
+      - name: Start database
         working-directory: ./packages/django-app
         run: |
-          docker volume create --name=oscarr_postgres
           docker compose up -d db
           ./bin/wait-for-it.sh localhost:5432 -- echo "db is up"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Production
 
 on:
   workflow_run:
-    workflows: ["CI"]
+    workflows: ["Lint and Test"]
     branches: [main]
     types: [completed]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Production
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types: [completed]
+
+jobs:
+  deploy:
+    name: Deploy to Production
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    environment: ci
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          PROD_DIR: ${{ vars.DO_PROD_DIR }}
+        with:
+          host: ${{ secrets.DO_SSH_HOST }}
+          username: ${{ secrets.DO_SSH_USER }}
+          key: ${{ secrets.DO_SSH_KEY }}
+          envs: PROD_DIR
+          script: |
+            cd "$PROD_DIR/packages/django-app"
+            just update-oscarr

--- a/packages/django-app/docker-compose.yml
+++ b/packages/django-app/docker-compose.yml
@@ -1,3 +1,5 @@
+name: oscarr
+
 volumes:
   oscarr_postgres:
     external: true

--- a/packages/django-app/docker-compose.yml
+++ b/packages/django-app/docker-compose.yml
@@ -38,3 +38,27 @@ services:
       - "127.0.0.1:8000:8000"
     depends_on:
       - db
+  bot:
+    profiles: ["bot"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - ./.env
+    environment:
+      - POSTGRES_HOST=db
+      - LOGS_DIR=/logs
+    working_dir: /code/app
+    command:
+      - '/code/bin/wait-for-it.sh'
+      - 'db:5432'
+      - '--'
+      - 'python'
+      - '/code/app/manage.py'
+      - 'start_discord_bot'
+    volumes:
+      - .:/code
+      - ./logs:/logs
+    depends_on:
+      - db
+    restart: unless-stopped

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -3,6 +3,10 @@ set dotenv-load
 default:
   @just --list
 
+# copy .env.template to .env if .env doesn't already exist
+copy-env:
+  test -f .env || cp .env.template .env
+
 # calls sync_with_plex django management command in the container
 sync-with-plex:
   ./bin/dcp-django-admin.sh sync_with_plex

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -7,10 +7,6 @@ default:
 sync-with-plex:
   ./bin/dcp-django-admin.sh sync_with_plex
 
-# stops the discord bot container
-stop-discord-bot:
-  docker compose --profile bot stop bot
-
 # starts the discord bot in a container (auto-restarts unless stopped)
 start-discord-bot:
   docker compose --profile bot up -d bot

--- a/packages/django-app/justfile
+++ b/packages/django-app/justfile
@@ -9,23 +9,15 @@ sync-with-plex:
 
 # stops the discord bot container
 stop-discord-bot:
-  #!/usr/bin/env bash
-  for CONTAINER_ID in $(docker ps -q --filter "ancestor=django-app-web" --filter "status=running"); do
-    COMMAND=$(docker inspect $CONTAINER_ID | jq -r '.[0].Config.Cmd | join(" ")')
-    if echo "$COMMAND" | grep -q "start_discord_bot"; then
-      echo "Stopping discord bot container: $CONTAINER_ID"
-      docker stop $CONTAINER_ID
-      exit 0
-    fi
-  done
-  echo "No running discord bot container found"
+  docker compose --profile bot stop bot
 
-# starts the discord bot in a container
+# starts the discord bot in a container (auto-restarts unless stopped)
 start-discord-bot:
-  docker compose run -d --rm -w /code/app web /code/app/manage.py start_discord_bot
+  docker compose --profile bot up -d bot
 
-# restart discord bot (stop then start)
-restart-discord-bot: stop-discord-bot start-discord-bot
+# restart discord bot
+restart-discord-bot:
+  docker compose --profile bot up -d --force-recreate bot
 
 # create python venv and install dependencies
 setup-local-python-venv:
@@ -42,7 +34,7 @@ create-json-backup location=default_backups_location:
 # pulls latest code, builds web image, migrates db, restarts web and bot containers
 update-oscarr:
   git pull origin main
-  docker compose build web
+  docker compose --profile bot build web bot
   ./bin/dcp-django-admin.sh migrate
   docker compose stop web
   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d web


### PR DESCRIPTION
## Summary
Refactored the Discord bot deployment to use a dedicated Docker Compose service with profiles instead of running it as a command on the web container. This improves service isolation, management, and enables independent scaling.

## Key Changes
- **docker-compose.yml**: Added a new `bot` service with profile `["bot"]` that:
  - Builds from the same Dockerfile as the web service
  - Runs the `start_discord_bot` management command
  - Mounts the same volumes and depends on the database
  - Configured with `restart: unless-stopped` for automatic recovery
  - Uses environment variables for PostgreSQL host and logs directory

- **justfile**: Simplified bot management commands:
  - `stop-discord-bot`: Changed from container inspection logic to `docker compose --profile bot stop bot`
  - `start-discord-bot`: Changed from `docker compose run` to `docker compose --profile bot up -d bot` with auto-restart capability
  - `restart-discord-bot`: Simplified to use `docker compose --profile bot up -d --force-recreate bot`
  - `update-oscarr`: Updated build command to include both web and bot services with profile flag

## Implementation Details
- The bot service uses Docker Compose profiles to keep it optional and separate from the default services
- The dedicated service approach provides better container lifecycle management and clearer separation of concerns
- Auto-restart behavior is now built into the service configuration rather than relying on manual management
- All bot management operations now use consistent `docker compose --profile bot` syntax

https://claude.ai/code/session_01RJrZb4X5Ywuzq2SjeFXgN1